### PR TITLE
Added proper error handling for task 6 - GET /api/articles/:article_id/comments

### DIFF
--- a/__tests__/integration-test.js
+++ b/__tests__/integration-test.js
@@ -150,21 +150,20 @@ describe("GET /api/articles/:article_id/comments", () => {
         expect(body.msg).toBe('Invalid input')
     })
   })
-  test("404 status code: 'No comments found!' if passed an id that has no associated comments", ()=>{
+  test("200 status code: resolves with an empty array if passed an article_id that exists but has no associated comments", ()=>{
     return request(app)
     .get('/api/articles/2/comments')
-    .expect(404)
+    .expect(200)
     .then(({body})=>{
-        expect(body.msg).toBe('No comments found!')
+        expect(body.comments).toEqual([])
     })
   })
-  test("404 status code: 'No comments found!' if passed an id that does not exist", ()=>{
+  test("404 status code: 'That article_id does not exist!' if passed an id that does not exist", ()=>{
     return request(app)
     .get('/api/articles/20/comments')
     .expect(404)
     .then(({body})=>{
-    expect(body.msg).toBe('No comments found!')
-    //I would like to be able to return a different comment for this scenario to say 'no articles exist with that id', but I'm not sure how to differentiate between this and the scenario above using rejected Promises
+    expect(body.msg).toBe('That article_id does not exist!')
   }) 
   })
  

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -1,4 +1,4 @@
-const {fetchArticleById, fetchArticles, fetchArticleCommentsByArticleId} = require("../models/articles.model")
+const {fetchArticleById, fetchArticles, fetchArticleCommentsByArticleId, checkArticleIdExists} = require("../models/articles.model")
 
 exports.getArticlesById = (req, res, next) =>{
     const {article_id} = req.params
@@ -18,9 +18,12 @@ fetchArticles().then((articles)=>{
 
 exports.getArticleCommentsByArticleId = (req, res, next)=>{
     const {article_id} = req.params
-    fetchArticleCommentsByArticleId(article_id).then((comments) =>{
+    const promisesArr = [fetchArticleCommentsByArticleId(article_id),
+        checkArticleIdExists(article_id)]
+    Promise.all(promisesArr)
+    .then((resolvedPromises)=>{
+        const comments = resolvedPromises[0]
         res.status(200).send({comments})
-    }).catch((err) =>{
-        next(err)
     })
+    .catch(next)
 }

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -26,10 +26,15 @@ exports.fetchArticles = ()=>{
 exports.fetchArticleCommentsByArticleId = (article_id)=>{
     return db.query("SELECT comment_id, votes, created_at, author, body,article_id FROM comments WHERE article_id = $1 ORDER BY created_at DESC", [article_id])
     .then(({rows})=>{
-        console.log(rows, 'rows')
-        if(rows.length ===0){
-            return Promise.reject({status: 404, msg:"No comments found!"})
-            }
         return rows
+    })
+}
+
+exports.checkArticleIdExists = (article_id)=>{
+    return db.query("SELECT * FROM articles WHERE article_id = $1", [article_id])
+    .then(({rows})=>{
+        if(rows.length ===0){
+            return Promise.reject({status: 404, msg:"That article_id does not exist!"})
+            }
     })
 }


### PR DESCRIPTION
Updated work for task 6 - GET /api/articles/:article_id/comments to deal with error handling:
- to give a 404 response when passed an article_id that doesn't exist
- to give a 200 : empty array response when passed an article_id that does exist but has no associated comments